### PR TITLE
Additional extra state attributes

### DIFF
--- a/custom_components/libreview/const.py
+++ b/custom_components/libreview/const.py
@@ -33,6 +33,7 @@ TREND_MESSAGE = {
     5: "increasing_fast",
 }
 
+
 class GlucoseUnitOfMeasurement(Enum):
     MMOLL = "mmol/L"
     MGDL = "mg/dl"

--- a/custom_components/libreview/sensor.py
+++ b/custom_components/libreview/sensor.py
@@ -18,6 +18,7 @@ from .const import (
     DOMAIN,
     SENSOR_ICON,
     TREND_ICONS,
+    TREND_MESSAGE,
     GlucoseUnitOfMeasurement,
 )
 from .coordinator import LibreViewCoordinator
@@ -150,5 +151,7 @@ class GlucoseSensor(CoordinatorEntity, SensorEntity):
             "target_high_mg_dl": self.connection.target_high,
             "target_low_mg_dl": self.connection.target_low,
             "trend": TREND_MESSAGE.get(self.trend_arrow, "unknown"),
-            "measurement_timestamp": self.gcm.factory_timestamp.replace(tzinfo=UTC),
+            "measurement_timestamp": self.gcm.factory_timestamp.replace(
+                tzinfo=timezone.utc
+            ),
         }


### PR DESCRIPTION
I recently bought an ulanzi tc001 for running awtrix3 to display my glucose measurements based on data from this integration.
I wanted to be able to show a trend arrow icon on the display based on the current trend as well as an indicator for how recent the measurement was. However, this data was not available from the currently implemented sensors and their attributes.

This PR adds the `trend` and `measurement_timestamp` attributes to the `glucose level` sensor. This allows for determining the trend of the glucose level and how old the current measurement is from the attributes in automations.

----

Should also fix https://github.com/PTST/LibreView-HomeAssistant/issues/39
