### PR TITLE
Fix mmol/l value when native value of the app is set to mg/dl

### DIFF
--- a/custom_components/libreview/sensor.py
+++ b/custom_components/libreview/sensor.py
@@ -143,7 +143,7 @@ class GlucoseSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def get_mmol_l_value(self) -> float:
-        if (app_uom == 1):
+        if self.app_uom == 1:
             return self.gcm_value_in_mg_per_dl / 18.0
         return self.gcm.value
 


### PR DESCRIPTION
Turns out that the .value returned from the api is not always in mmol/l as assumed. Instead it seems to be the native value that the libre app is set to.

So we calculate the mmol/l ourselves from the fixed mg/dl value provided 
Should fix #48 